### PR TITLE
tniASM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ The **Z80 Macro-Assembler** extension for Visual Studio Code provides the follow
   - [Macroassembler AS](http://john.ccac.rwth-aachen.de:8000/as/)
   - [Pasmo](http://pasmo.speccy.org/)
   - [rasm](http://www.roudoudou.com/rasm/)
-  - [tniASM](http://www.tni.nl/products/tniasm.html) (v0.x series)
-* [problem matchers](#problem-matchers) for **SjASMPlus**, **Macroassembler AS** and **tniASM** compilation output
+* [problem matchers](#problem-matchers) for **SjASMPlus** and **Macroassembler AS** compilation output
 * label and symbol documenter on hover, defintion provider, completition proposer
 * snippets for macros and source control keywords
 
@@ -17,7 +16,6 @@ The **Z80 Macro-Assembler** extension for Visual Studio Code provides the follow
 There are some predefined problem matchers to handle reported errors from compilation output:
 - `errmatcher-as` for **Macroassembler AS**
 - `errmatcher-sjasmplus` for **SjASMPlus**
-- `errmatcher-tniasm` and `errmatcher-tniasm-preprocessor` for **tniASM**
 
 These values can be used in `.vscode/tasks.json` of your project's build task, for example:
 ```json

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ The **Z80 Macro-Assembler** extension for Visual Studio Code provides the follow
   - [Macroassembler AS](http://john.ccac.rwth-aachen.de:8000/as/)
   - [Pasmo](http://pasmo.speccy.org/)
   - [rasm](http://www.roudoudou.com/rasm/)
-* [problem matchers](#problem-matchers) for **SjASMPlus** and **Macroassembler AS** compilation output
+  - [tniASM](http://www.tni.nl/products/tniasm.html) (v0.x series)
+* [problem matchers](#problem-matchers) for **SjASMPlus**, **Macroassembler AS** and **tniASM** compilation output
 * label and symbol documenter on hover, defintion provider, completition proposer
 * snippets for macros and source control keywords
 
@@ -16,6 +17,7 @@ The **Z80 Macro-Assembler** extension for Visual Studio Code provides the follow
 There are some predefined problem matchers to handle reported errors from compilation output:
 - `errmatcher-as` for **Macroassembler AS**
 - `errmatcher-sjasmplus` for **SjASMPlus**
+- `errmatcher-tniasm` and `errmatcher-tniasm-preprocessor` for **tniASM**
 
 These values can be used in `.vscode/tasks.json` of your project's build task, for example:
 ```json

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "z80-macroasm",
     "displayName": "Z80 Macro-Assembler",
     "description": "Support for Z80 macro-assemblers in Visual Studio Code",
-    "version": "0.4.0",
+    "version": "0.3.3",
     "icon": "logo.png",
     "publisher": "mborik",
     "categories": [
@@ -17,8 +17,7 @@
         "Sinclair",
         "ZX-Spectrum",
         "Amstrad",
-        "CPC",
-        "MSX"
+        "CPC"
     ],
     "homepage": "https://github.com/mborik/z80-macroasm-vscode",
     "bugs": "https://github.com/mborik/z80-macroasm-vscode/issues",
@@ -67,36 +66,6 @@
                         "line": 2,
                         "severity": 3,
                         "message": 4
-                    }
-                ]
-            },
-            {
-                "name": "errmatcher-tniasm",
-                "owner": "z80-macroasm",
-                "fileLocation": [
-                    "relative",
-                    "${workspaceFolder}"
-                ],
-                "pattern": [
-                    {
-                        "regexp": "^(Warning|Error|Syntax Error) in line (\\d+) \\(([^)]+)\\): (.*)$",
-                        "severity": 1,
-                        "line": 2,
-                        "file": 3,
-                        "message": 4
-                    }
-                ]
-            },
-            {
-                "name": "errmatcher-tniasm-preprocessor",
-                "owner": "z80-macroasm",
-                "pattern": [
-                    {
-                        "kind": "file",
-                        "regexp": "^(Warning|Error) .* (\\S+)! .*$",
-                        "message": 0,
-                        "severity": 1,
-                        "file": 2
                     }
                 ]
             }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "z80-macroasm",
     "displayName": "Z80 Macro-Assembler",
     "description": "Support for Z80 macro-assemblers in Visual Studio Code",
-    "version": "0.3.3",
+    "version": "0.4.0",
     "icon": "logo.png",
     "publisher": "mborik",
     "categories": [
@@ -17,7 +17,8 @@
         "Sinclair",
         "ZX-Spectrum",
         "Amstrad",
-        "CPC"
+        "CPC",
+        "MSX"
     ],
     "homepage": "https://github.com/mborik/z80-macroasm-vscode",
     "bugs": "https://github.com/mborik/z80-macroasm-vscode/issues",
@@ -66,6 +67,36 @@
                         "line": 2,
                         "severity": 3,
                         "message": 4
+                    }
+                ]
+            },
+            {
+                "name": "errmatcher-tniasm",
+                "owner": "z80-macroasm",
+                "fileLocation": [
+                    "relative",
+                    "${workspaceFolder}"
+                ],
+                "pattern": [
+                    {
+                        "regexp": "^(Warning|Error|Syntax Error) in line (\\d+) \\(([^)]+)\\): (.*)$",
+                        "severity": 1,
+                        "line": 2,
+                        "file": 3,
+                        "message": 4
+                    }
+                ]
+            },
+            {
+                "name": "errmatcher-tniasm-preprocessor",
+                "owner": "z80-macroasm",
+                "pattern": [
+                    {
+                        "kind": "file",
+                        "regexp": "^(Warning|Error) .* (\\S+)! .*$",
+                        "message": 0,
+                        "severity": 1,
+                        "file": 2
                     }
                 ]
             }

--- a/snippets/z80-macroasm.json
+++ b/snippets/z80-macroasm.json
@@ -200,21 +200,5 @@
             "endstruct"
         ],
         "description": "Structure creation by rasm"
-    },
-    "msx-cartridge-header": {
-        "prefix": "msx",
-        "body": [
-            "\tdb\t\"AB\"\t; ROM Catridge ID (\"AB\")",
-            "\tdw\tINIT\t; INIT",
-            "\tdw\t\\$0000\t; STATEMENT",
-            "\tdw\t\\$0000\t; DEVICE",
-            "\tdw\t\\$0000\t; TEXT",
-            "\tdw\t\\$0000\t; Reserved",
-            "\tdw\t\\$0000",
-            "\tdw\t\\$0000",
-            "INIT:",
-            "\t$0"
-        ],
-        "description": "MSX ROM cartridge header"
     }
 }

--- a/snippets/z80-macroasm.json
+++ b/snippets/z80-macroasm.json
@@ -200,5 +200,21 @@
             "endstruct"
         ],
         "description": "Structure creation by rasm"
+    },
+    "msx-cartridge-header": {
+        "prefix": "msx",
+        "body": [
+            "\tdb\t\"AB\"\t; ROM Catridge ID (\"AB\")",
+            "\tdw\tINIT\t; INIT",
+            "\tdw\t\\$0000\t; STATEMENT",
+            "\tdw\t\\$0000\t; DEVICE",
+            "\tdw\t\\$0000\t; TEXT",
+            "\tdw\t\\$0000\t; Reserved",
+            "\tdw\t\\$0000",
+            "\tdw\t\\$0000",
+            "INIT:",
+            "\t$0"
+        ],
+        "description": "MSX ROM cartridge header"
     }
 }

--- a/syntaxes/z80-macroasm.tmLanguage.json
+++ b/syntaxes/z80-macroasm.tmLanguage.json
@@ -30,6 +30,11 @@
 					"end": "\\*/"
 				},
 				{
+					"name": "comment.block.z80asm",
+					"begin": "{",
+					"end": "}"
+				},
+				{
 					"name": "comment.line.z80asm",
 					"begin": ";",
 					"end": "\\n"
@@ -40,19 +45,19 @@
 			"patterns": [
 				{
 					"name": "keyword.control.z80asm",
-					"match": "(?i:(?<=\\s)(?:equ|eval|org|end?t|align|(de|un)?phase|shift|save(bin|hob|sna|tap|trd)|empty(tap|trd)|inc(bin|hob|trd)|b?include|insert|binary|end|output|tap(out|end)|fpos|page|slot|size|outradix)\\b)"
+					"match": "(?i:(?:equ|eval|f?org|end?t|align|(de|un)?phase|shift|save(bin|hob|sna|tap|trd)|empty(tap|trd)|inc(bin|hob|trd)|b?include|insert|binary|end|output|fname|tap(out|end)|fpos|page|slot|size|outradix)\\b)"
 				},
 				{
 					"name": "keyword.control.z80asm",
-					"match": "(?i:(?<=\\s)(?:cpu|device|encoding|charset|proc|macro|local|shared|public|rept|dup|block|endm|endp|edup|exitm|module|endmod(ule)?|(un)?define|export|disp|textarea|map|field|defarray)\\b)"
+					"match": "(?i:(?:cpu|device|encoding|charset|proc|macro|local|shared|public|rept|dup|block|endm|endp|edup|exitm|module|endmod(ule)?|(un)?define|export|disp|textarea|map|field|defarray)\\b)"
 				},
 				{
 					"name": "keyword.control.z80asm",
-					"match": "(?i:(?<=\\s)(?:assert|fatal|error|warning|message|display|shellexec|def[bdlmswir]|d[bcdszw]|abyte[cz]?|byte|word|dword)\\b)"
+					"match": "(?i:(?:assert|fatal|error|warning|message|display|shellexec|def[bdlmswir]|d[bcdszw]|abyte[cz]?|byte|word|dword|r[bw])\\b)"
 				},
 				{
 					"name": "keyword.control.z80asm",
-					"match": "(?i:(?<=\\s)(?:if|ifn?def|ifn?used|else|elseif|endif)\\b)"
+					"match": "(?i:(?:if|ifn?def|ifexist|ifn?used|else|elseif|endif)\\b)"
 				},
 				{
 					"name": "keyword.control.z80asm",

--- a/syntaxes/z80-macroasm.tmLanguage.json
+++ b/syntaxes/z80-macroasm.tmLanguage.json
@@ -30,11 +30,6 @@
 					"end": "\\*/"
 				},
 				{
-					"name": "comment.block.z80asm",
-					"begin": "{",
-					"end": "}"
-				},
-				{
 					"name": "comment.line.z80asm",
 					"begin": ";",
 					"end": "\\n"
@@ -45,19 +40,19 @@
 			"patterns": [
 				{
 					"name": "keyword.control.z80asm",
-					"match": "(?i:(?:equ|eval|f?org|end?t|align|(de|un)?phase|shift|save(bin|hob|sna|tap|trd)|empty(tap|trd)|inc(bin|hob|trd)|b?include|insert|binary|end|output|fname|tap(out|end)|fpos|page|slot|size|outradix)\\b)"
+					"match": "(?i:(?<=\\s)(?:equ|eval|org|end?t|align|(de|un)?phase|shift|save(bin|hob|sna|tap|trd)|empty(tap|trd)|inc(bin|hob|trd)|b?include|insert|binary|end|output|tap(out|end)|fpos|page|slot|size|outradix)\\b)"
 				},
 				{
 					"name": "keyword.control.z80asm",
-					"match": "(?i:(?:cpu|device|encoding|charset|proc|macro|local|shared|public|rept|dup|block|endm|endp|edup|exitm|module|endmod(ule)?|(un)?define|export|disp|textarea|map|field|defarray)\\b)"
+					"match": "(?i:(?<=\\s)(?:cpu|device|encoding|charset|proc|macro|local|shared|public|rept|dup|block|endm|endp|edup|exitm|module|endmod(ule)?|(un)?define|export|disp|textarea|map|field|defarray)\\b)"
 				},
 				{
 					"name": "keyword.control.z80asm",
-					"match": "(?i:(?:assert|fatal|error|warning|message|display|shellexec|def[bdlmswir]|d[bcdszw]|abyte[cz]?|byte|word|dword|r[bw])\\b)"
+					"match": "(?i:(?<=\\s)(?:assert|fatal|error|warning|message|display|shellexec|def[bdlmswir]|d[bcdszw]|abyte[cz]?|byte|word|dword)\\b)"
 				},
 				{
 					"name": "keyword.control.z80asm",
-					"match": "(?i:(?:if|ifn?def|ifexist|ifn?used|else|elseif|endif)\\b)"
+					"match": "(?i:(?<=\\s)(?:if|ifn?def|ifn?used|else|elseif|endif)\\b)"
 				},
 				{
 					"name": "keyword.control.z80asm",

--- a/syntaxes/z80-macroasm.tmLanguage.json
+++ b/syntaxes/z80-macroasm.tmLanguage.json
@@ -30,6 +30,11 @@
 					"end": "\\*/"
 				},
 				{
+					"name": "comment.block.z80asm",
+					"begin": "{",
+					"end": "}"
+				},
+				{
 					"name": "comment.line.z80asm",
 					"begin": ";",
 					"end": "\\n"
@@ -73,6 +78,10 @@
 				{
 					"name": "keyword.control.z80asm",
 					"match": "(?i:(?<=\\s)(?:list|nolist|let)\\b)"
+				},
+				{
+					"name": "keyword.control.z80asm",
+					"match": "(?i:\\b(d[bcsw]|fname|f?org|incbin|include|(?:de)?phase|r[bw]|if|ifdef|ifexist|else|endif|cpu\\s(?:z80|r800|msx|gbz80))\\b)"
 				},
 				{
 					"name": "string.other.lua.z80asm",


### PR DESCRIPTION
Adds tniASM (v0.x series) support: syntax highlight and problem matchers.
Main syntax differences are: some extra directives (IFEXIST) and relaxed whitespace constraints.

Also, adds a new snippet (MSX ROM cartridge header).