### PR TITLE
Fixes IXH and IYH not being highlighted

### DIFF
--- a/src/completionProposer.ts
+++ b/src/completionProposer.ts
@@ -20,10 +20,10 @@ const instructionSet = [
 const registerSet = [
 	/*  0 */ 'a', 'b', 'c', 'd', 'e', 'h', 'l', 'i', 'r',
 	/*  9 */ '(hl)', '(de)', '(bc)', '(ix+*)', '(iy+*)',
-	/* 14 */ 'ixl', 'ixu', 'lx', 'hx', 'xl', 'xh',
-	/* 20 */ 'iyl', 'iyu', 'ly', 'hy', 'yl', 'yh',
-	/* 26 */ 'hl', 'de', 'bc', 'af', 'ix', 'iy',
-	/* 32 */ 'sp', '(sp)', '(ix)', '(iy)'
+	/* 14 */ 'ixl', 'ixh', 'ixu', 'lx', 'hx', 'xl', 'xh',
+	/* 21 */ 'iyl', 'iyh', 'iyu', 'ly', 'hy', 'yl', 'yh',
+	/* 28 */ 'hl', 'de', 'bc', 'af', 'ix', 'iy',
+	/* 34 */ 'sp', '(sp)', '(ix)', '(iy)'
 ];
 
 export class ASMCompletionProposer implements vscode.CompletionItemProvider {
@@ -78,11 +78,11 @@ export class ASMCompletionProposer implements vscode.CompletionItemProvider {
 			let idxStart = 0, idxEnd = undefined;
 
 			if (shouldSuggest1ArgRegisterMatch[1]) {
-				idxStart = 26;
-				idxEnd = 31;
+				idxStart = 28;
+				idxEnd = 33;
 			}
 			else if (shouldSuggest1ArgRegisterMatch[2]) {
-				idxEnd = 25;
+				idxEnd = 27;
 			}
 
 			output = registerSet.slice(idxStart, idxEnd).map((snippet, idx) => {

--- a/syntaxes/z80-macroasm.tmLanguage.json
+++ b/syntaxes/z80-macroasm.tmLanguage.json
@@ -190,7 +190,7 @@
 				},
 				{
 					"name": "support.type.register.z80asm",
-					"match": "\\b(?i:[abcdefhlir]|ix|iy|af'?|bc|de|hl|pc|sp|i?[xy][lh]|[lh][xy])\\b"
+					"match": "\\b(?i:[abcdefhlir]|ix|iy|af'?|bc|de|hl|pc|sp|ix[lu]|iy[lu]|[lh]x|x[lh]|[lh]y|y[lh])\\b"
 				},
 				{
 					"name": "constant.language.operator.z80asm",

--- a/syntaxes/z80-macroasm.tmLanguage.json
+++ b/syntaxes/z80-macroasm.tmLanguage.json
@@ -190,7 +190,7 @@
 				},
 				{
 					"name": "support.type.register.z80asm",
-					"match": "\\b(?i:[abcdefhlir]|ix|iy|af'?|bc|de|hl|pc|sp|ix[lu]|iy[lu]|[lh]x|x[lh]|[lh]y|y[lh])\\b"
+					"match": "\\b(?i:[abcdefhlir]|ix|iy|af'?|bc|de|hl|pc|sp|ix[hlu]|iy[hlu]|[lh]x|x[lh]|[lh]y|y[lh])\\b"
 				},
 				{
 					"name": "constant.language.operator.z80asm",

--- a/syntaxes/z80-macroasm.tmLanguage.json
+++ b/syntaxes/z80-macroasm.tmLanguage.json
@@ -190,7 +190,7 @@
 				},
 				{
 					"name": "support.type.register.z80asm",
-					"match": "\\b(?i:[abcdefhlir]|ix|iy|af'?|bc|de|hl|pc|sp|ix[lu]|iy[lu]|[lh]x|x[lh]|[lh]y|y[lh])\\b"
+					"match": "\\b(?i:[abcdefhlir]|ix|iy|af'?|bc|de|hl|pc|sp|i?[xy][lh]|[lh][xy])\\b"
 				},
 				{
 					"name": "constant.language.operator.z80asm",


### PR DESCRIPTION
This commit fixes the problem described by Laurens Holst in [Twitter](https://twitter.com/Grauw/status/1172644842033360896):

> [...] ixl and iyl are highlighted like the other registers, but ixh and iyh are not

It looked like a simple typo (there was an `u` instead of an `h` in the regex).