### PR TITLE
On-type formatter improvements

### DIFF
--- a/src/completionProposer.ts
+++ b/src/completionProposer.ts
@@ -67,6 +67,18 @@ export class Z80CompletionProposer extends ConfigPropsProvider implements vscode
 			prefix = ' ';
 		}
 
+		// When formatOnType is enabled, don't add newline after the autocomplete, it will also create a new line in the editor where we only want enter to confirm the item.
+		let suffix = options.eol;
+		if (options.formatOnType) {
+			suffix = '';
+		}
+
+		// Commit characters are slightly different: for first character, comma is accepted, for second space. And for both tab and enter as well.
+		let commitChars = [' ', '\t', '\n'];
+		if (!options.secondArgument) {
+			commitChars = [',', '\t', '\n'];
+		}
+
 		if (options.bracketType === 'square' && snippet.indexOf('(') === 0) {
 			snippet = snippet.replace('(', '[').replace(')', ']');
 		}
@@ -74,13 +86,13 @@ export class Z80CompletionProposer extends ConfigPropsProvider implements vscode
 		const item = new vscode.CompletionItem(snippet, vscode.CompletionItemKind.Value);
 		const snip = new vscode.SnippetString(prefix + snippet.replace('*', '${1:0}'));
 
-		snip.appendText(options.eol);
+		snip.appendText(suffix);
 		snip.appendTabstop(0);
 
 		// put on the top of the list...
 		item.sortText = `!${pad(idx)}`;
 		item.insertText = snip;
-		item.commitCharacters = ['\n'];
+		item.commitCharacters = commitChars;
 		return item;
 	}
 

--- a/src/completionProposer.ts
+++ b/src/completionProposer.ts
@@ -61,8 +61,9 @@ export class Z80CompletionProposer extends ConfigPropsProvider implements vscode
 
 		snippet = uppercaseIfNeeded(snippet, ucase);
 
+		// Add space before selected autocompletion, unless user has formatOnType enabled; in this case, formatter will already add the space by the time intellisense menu is shown. If we also let space here, we'll end up with 2 spaces.
 		let prefix = '';
-		if (options.secondArgument && options.spaceAfterArgument) {
+		if (options.secondArgument && options.spaceAfterArgument && !options.formatOnType) {
 			prefix = ' ';
 		}
 

--- a/src/configProperties.ts
+++ b/src/configProperties.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { EXTENSION_LANGUAGE_ID } from './extension';
 
 export interface ConfigProps {
 	indentSpaces: boolean;
@@ -15,20 +16,22 @@ export interface ConfigProps {
 	colonAfterLabels: 'no-change' | boolean;
 	hexaNumberStyle: 'no-change' | 'hash' | 'motorola' | 'intel' | 'intel-uppercase' | 'c-style';
 	hexaNumberCase: 'no-change' | boolean;
+	formatOnType: boolean;
 }
 
 export abstract class ConfigPropsProvider {
 	constructor(public settings: vscode.WorkspaceConfiguration) {}
 
 	getConfigProps(document: vscode.TextDocument) {
-		const config = vscode.workspace.getConfiguration();
+		const config = vscode.workspace.getConfiguration(undefined, { languageId: EXTENSION_LANGUAGE_ID });
 
 		const result: ConfigProps = {
 			...this.settings?.format,
 
 			indentSpaces: (config.editor.insertSpaces === 'true'),
 			indentSize: parseInt(config.editor.tabSize as any, 10) || 8,
-			eol: (config.files.eol === vscode.EndOfLine.CRLF) ? '\r\n' : '\n'
+			eol: (config.files.eol === vscode.EndOfLine.CRLF) ? '\r\n' : '\n',
+			formatOnType: config.editor.formatOnType
 		};
 
 		result.indentDetector = RegExp('^' +

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,8 @@ let changeConfigSubscription: vscode.Disposable | undefined;
 let symbolProcessor: SymbolProcessor | undefined;
 let formatProcessor: FormatProcessor | undefined;
 
+export const EXTENSION_LANGUAGE_ID = 'z80-macroasm';
+
 export function activate(ctx: vscode.ExtensionContext) {
 	configure(ctx);
 
@@ -34,13 +36,12 @@ export function deactivate() {
 }
 
 function configure(ctx: vscode.ExtensionContext, event?: vscode.ConfigurationChangeEvent) {
-	const language = 'z80-macroasm';
-	const settings = vscode.workspace.getConfiguration(language);
-	const languageSelector: vscode.DocumentFilter = { language, scheme: 'file' };
+	const settings = vscode.workspace.getConfiguration(EXTENSION_LANGUAGE_ID);
+	const languageSelector: vscode.DocumentFilter = { language: EXTENSION_LANGUAGE_ID, scheme: 'file' };
 
 	// test if changing specific configuration
 	let formatterEnableDidChange = false;
-	if (event && event.affectsConfiguration(language)) {
+	if (event && event.affectsConfiguration(EXTENSION_LANGUAGE_ID)) {
 		formatterEnableDidChange = settings.format.enabled !== (formatProcessor?.settings.format.enabled || false);
 
 		if (symbolProcessor) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,7 +78,7 @@ function configure(ctx: vscode.ExtensionContext, event?: vscode.ConfigurationCha
 		ctx.subscriptions.push(
 			vscode.languages.registerDocumentFormattingEditProvider(languageSelector, new Z80DocumentFormatter(formatProcessor)),
 			vscode.languages.registerDocumentRangeFormattingEditProvider(languageSelector, new Z80DocumentRangeFormatter(formatProcessor)),
-			vscode.languages.registerOnTypeFormattingEditProvider(languageSelector, new Z80TypingFormatter(formatProcessor), ' ', ',', ';', ':'),
+			vscode.languages.registerOnTypeFormattingEditProvider(languageSelector, new Z80TypingFormatter(formatProcessor), ' ', ',', ';', ':', '\n'),
 		);
 	}
 

--- a/src/formatProcessor.ts
+++ b/src/formatProcessor.ts
@@ -14,16 +14,11 @@ interface LineParts extends LinePartFrag {
 	fragments?: LinePartFrag[];
 }
 
-interface SourceInfo {
-	isOnType: boolean;
-	char: string;
-}
-
 type FormatProcessorOutput = vscode.ProviderResult<vscode.TextEdit[]>;
 type EvalSpecificRegExpExecArray = RegExpExecArray & { notIndented?: boolean } | null;
 
 export class FormatProcessor extends ConfigPropsProvider {
-	format(document: vscode.TextDocument, range: vscode.Range, sourceInfo?: SourceInfo): FormatProcessorOutput {
+	format(document: vscode.TextDocument, range: vscode.Range, isOnType: boolean = false): FormatProcessorOutput {
 		const configProps = this.getConfigProps(document);
 		const startLineNumber = document.lineAt(range.start).lineNumber;
 		const endLineNumber = document.lineAt(range.end).lineNumber;
@@ -325,11 +320,11 @@ export class FormatProcessor extends ConfigPropsProvider {
 					});
 				}
 			);
- 
-			var result = newText.join('');
+
+			let result = newText.join('');
 
 			// Don't trim for on-type formatting, it interferes with typing, much more fluent this way.
-			if (!sourceInfo?.isOnType) {
+			if (!isOnType) {
 				result = result.trimEnd();
 			}
 
@@ -362,12 +357,11 @@ export class Z80TypingFormatter implements vscode.OnTypeFormattingEditProvider {
 
 	provideOnTypeFormattingEdits(document: vscode.TextDocument, position: vscode.Position, ch: string): FormatProcessorOutput {
 		// If enter is pressed, we should format the line that was being edited before, not the new line.
-		var line = position.line;
-		if (ch == '\n' && line > 0) {
+		let line = position.line;
+		if (ch === '\n' && line > 0) {
 			line--;
 		}
 
-		const sourceInfo: SourceInfo = { isOnType: true, char: ch };
-		return this.formatter.format(document, document.lineAt(line).range, sourceInfo);
+		return this.formatter.format(document, document.lineAt(line).range, true);
 	}
 }


### PR DESCRIPTION
Previously, the text was always trimmed at end, but this interfered with preformatted text when on-type formatter was used. With this change, typing is much more fluent.

Also added enter key as on-type format trigger. When pressed, format for previous line is invoked. This works quite well when typing but it invokes formatter also for example when initially opening the file and pressing enter to start typing new line. It should be fine given same formatting is usually desired over the whole file, but may be unexpected. Not sure if this is detectable though...

I tested the change for paste and format on save too, as well as for different formatting options, and all was fine. But am not very knowledgable in JS, so maybe I missed something. If anything raises your concerns, please let me know!