### PR TITLE
Add support for EXA and EXD shorthand mnemonics

### DIFF
--- a/src/defs_list.ts
+++ b/src/defs_list.ts
@@ -5,13 +5,14 @@ export default {
 	instructions: [
 		'adc\t',  'add\t',  'and\t',  'bit\t',  'call\t', 'ccf\n',  'cp\t',   'cpd\n',
 		'cpdr\n', 'cpi\n',  'cpir\n', 'cpl\n',  'daa\n',  'dec\t',  'di\n',   'ei\n',
-		'djnz\t', 'ex\t',   'exx\n',  'halt\n', 'im\t',   'in\t',   'inc\t',  'ind\n',
-		'indr\n', 'ini\n',  'inir\n', 'jp\t',   'jr\t',   'ld\t',   'ldd\n',  'lddr\n',
-		'ldi\n',  'ldir\n', 'neg\n',  'nop\n',  'or\t',   'otdr\n', 'otir\n', 'out\t',
-		'outd\n', 'outi\n', 'pop\t',  'push\t', 'res\t',  'ret\t',  'reti\n', 'retn\n',
-		'rl\t',   'rla\n',  'rlc\t',  'rlca\n', 'rld\n',  'rr\t',   'rra\n',  'rrc\t',
-		'rrca\n', 'rrd\n',  'rst\t',  'sbc\t',  'scf\n',  'set\t',  'sla\t',  'slia\t',
-		'sll\t',  'sl1\t',  'swap\t', 'sra\t',  'srl\t',  'sub\t',  'xor\t'
+		'djnz\t', 'ex\t',   'exa\n',  'exd\n',  'exx\n',  'halt\n', 'im\t',   'in\t',
+		'inc\t',  'ind\n',  'indr\n', 'ini\n',  'inir\n', 'jp\t',   'jr\t',   'ld\t',
+		'ldd\n',  'lddr\n', 'ldi\n',  'ldir\n', 'neg\n',  'nop\n',  'or\t',   'otdr\n',
+		'otir\n', 'out\t',  'outd\n', 'outi\n', 'pop\t',  'push\t', 'res\t',  'ret\t',
+		'reti\n', 'retn\n', 'rl\t',   'rla\n',  'rlc\t',  'rlca\n', 'rld\n',  'rr\t',
+		'rra\n',  'rrc\t',  'rrca\n', 'rrd\n',  'rst\t',  'sbc\t',  'scf\n',  'set\t',
+		'sla\t',  'slia\t', 'sll\t',  'sl1\t',  'swap\t', 'sra\t',  'srl\t',  'sub\t',
+		'xor\t'
 	],
 	// Z80N - ZX-Spectrum Next extended instruction set
 	nextInstructions: [

--- a/src/defs_regex.ts
+++ b/src/defs_regex.ts
@@ -74,7 +74,7 @@ export default {
 		bank|bankset|limit|protect|write\s+direct|str|
 		def[bdlmswir]|d[bcdszw]|abyte[cz]?|byte|d?word|hex|
 		if|ifn?def|ifn?used|ifn?exist|else(?:if)?|endif|
-		ad[cd]|and|bit|call|ccf|cp|cp[di]r?|cpl|daa|dec|[de]i|djnz|exx?|halt|
+		ad[cd]|and|bit|call|ccf|cp|cp[di]r?|cpl|daa|dec|[de]i|djnz|ex[adx]?|halt|
 		i[mn]|inc|in[di]r?|j[pr]|ld|ld[di]r?|neg|nop|ot[di]r|out|out[di]|
 		pop|push|res|ret[in]?|rla?|rlca?|r[lr]d|rra?|rrca?|rst|sbc|scf|set|
 		s[lr]a|s[lr]l|slia|sl1|sub|x?or|

--- a/syntaxes/z80-macroasm.tmLanguage.json
+++ b/syntaxes/z80-macroasm.tmLanguage.json
@@ -204,7 +204,7 @@
         },
         {
           "name": "keyword.mnemonic.z80asm",
-          "match": "\\s(?i:ad[cd]|and|bit|ccf|cp|cp[di]r?|cpl|daa|dec|[de]i|djnz|exx?|halt|i[mn]|inc|in[di]r?|ld|ld[di]r?|neg|nop|or|ot[di]r|out|out[di]|pop|push|res|ret[in]|rla?|rlca?|r[lr]d|rra?|rrca?|rst|sbc|scf|set|s[lr]a|s[lr]l|slia|sl1|sub|x?or)\\s"
+          "match": "\\s(?i:ad[cd]|and|bit|ccf|cp|cp[di]r?|cpl|daa|dec|[de]i|djnz|ex[adx]?|halt|i[mn]|inc|in[di]r?|ld|ld[di]r?|neg|nop|or|ot[di]r|out|out[di]|pop|push|res|ret[in]|rla?|rlca?|r[lr]d|rra?|rrca?|rst|sbc|scf|set|s[lr]a|s[lr]l|slia|sl1|sub|x?or)\\s"
         },
         {
           "name": "keyword.mnemonic.z80asm",


### PR DESCRIPTION
Hi Martin,

This PR (hopefully) adds support for `EXA` (=`EX AF, AF'`) and `EXD` (=`EX DE, HL`) shorthand mnemonics.
Both are supported by at least `sjasmplus` and are used quite often so it might be worth adding them.